### PR TITLE
Modif supp

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -2,6 +2,8 @@ class DashboardsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @flats = current_user.flats
+    @flat = Flat.new
     @user = current_user
 
     @bookings_count = @user.bookings.count

--- a/app/controllers/flats_controller.rb
+++ b/app/controllers/flats_controller.rb
@@ -13,7 +13,10 @@ class FlatsController < ApplicationController
     @flat.photos.attach(params[:flat][:photos]) if params[:flat][:photos].present?
 
     if @flat.save
-      redirect_to dashboard_path, notice: "Logement ajouté."
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to dashboard_path, notice: "Logement créé avec succès." }
+      end
     else
       render :new, status: :unprocessable_entity
     end
@@ -21,7 +24,7 @@ class FlatsController < ApplicationController
 
   def destroy
     @flat = Flat.find(params[:id])
-    
+
     if @flat.destroy
       redirect_to dashboard_path, notice: "Logement supprimé."
     else

--- a/app/controllers/flats_controller.rb
+++ b/app/controllers/flats_controller.rb
@@ -21,8 +21,12 @@ class FlatsController < ApplicationController
 
   def destroy
     @flat = Flat.find(params[:id])
-    @flat.destroy
-    redirect_to dashboard_path, notice: "Logement supprimé."
+    
+    if @flat.destroy
+      redirect_to dashboard_path, notice: "Logement supprimé."
+    else
+      redirect_to dashboard_path, alert: "Erreur : #{@flat.errors.full_messages.join(", ")}"
+    end
     # respond_to do |format|
     #   format.turbo_stream
     #   format.html { redirect_to dashboard_path, notice: "Logement supprimé." }

--- a/app/controllers/flats_controller.rb
+++ b/app/controllers/flats_controller.rb
@@ -26,14 +26,13 @@ class FlatsController < ApplicationController
     @flat = Flat.find(params[:id])
 
     if @flat.destroy
-      redirect_to dashboard_path, notice: "Logement supprimé."
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_to dashboard_path, notice: "Logement supprimé." }
+      end
     else
       redirect_to dashboard_path, alert: "Erreur : #{@flat.errors.full_messages.join(", ")}"
     end
-    # respond_to do |format|
-    #   format.turbo_stream
-    #   format.html { redirect_to dashboard_path, notice: "Logement supprimé." }
-    # end
   end
 
   private

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -4,7 +4,6 @@ export default class extends Controller {
   static targets = ["form"]
 
   connect() {
-    console.log("stimulus connecté")
   }
 
   toggle() {

--- a/app/models/flat.rb
+++ b/app/models/flat.rb
@@ -3,7 +3,6 @@ class Flat < ApplicationRecord
   belongs_to :user
 
   has_many :bookings, dependent: :destroy
-
   has_many :flat_reviews
 
   geocoded_by :address

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -55,7 +55,7 @@
                     <% if @flats.any? %>
                       <ul class="list-unstyled">
                         <% @flats.each do |flat| %>
-                          <turbo-frame id="flat_<%= flat.id %>">
+                          <%# <turbo-frame id="flat_<%= flat.id %>
                             <li class="mb-3">
                               <div class="flat-item d-flex justify-content-between align-items-start">
                                 <div>
@@ -68,13 +68,11 @@
                                               class: 'btn btn-sm btn-outline-primary',
                                               data: { turbo_frame: "flat_#{flat.id}" } %>
 
-                                  <%= link_to 'Supprimer', flat,
-                                              data: { turbo_methode: :delete, turbo_confirm: "Supprimer ce logement ?"},
-                                              class: 'btn btn-sm btn-outline-danger' %>
+                                  <%= link_to "Supprimer", flat, data: { turbo_method: :delete, confirm: "Es-tu sûr ?" } %>
                                 </div>
                               </div>
                             </li>
-                          </turbo-frame>
+                          <%# </turbo-frame> %>
                         <% end %>
                       </ul>
                     <% else %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -53,26 +53,10 @@
               <div class="card-body">
                   <h3 class="card-title">Manage my flats</h3>
                     <% if @flats.any? %>
-                      <ul class="list-unstyled">
+                      <ul class="list-unstyled" id="flats-list">
+                        <%= turbo_stream_from "flats" %>
                         <% @flats.each do |flat| %>
-                          <%# <turbo-frame id="flat_<%= flat.id %>
-                            <li class="mb-3">
-                              <div class="flat-item d-flex justify-content-between align-items-start">
-                                <div>
-                                  <h5 class="mb-1"><%= flat.name %></h5>
-                                  <p class="mb-0 text-muted"><%= flat.address %></p>
-                                </div>
-
-                                <div class="btn-group" role="group">
-                                  <%# <%= link_to 'Modifier', edit_flat_path(flat),
-                                              class: 'btn btn-sm btn-outline-primary',
-                                              data: { turbo_frame: "flat_#{flat.id}" } %>
-
-                                  <%= link_to "Supprimer", flat, data: { turbo_method: :delete, confirm: "Es-tu sûr ?" } %>
-                                </div>
-                              </div>
-                            </li>
-                          <%# </turbo-frame> %>
+                          <%= render partial: "flats/card", locals: { flat: flat } %>
                         <% end %>
                       </ul>
                     <% else %>
@@ -101,42 +85,14 @@
     <div class="col-lg-12 d-flex flex-column align-items-center">
       <turbo-frame id="new_flat" class="form-wrapper">
         <div data-controller="toggle">
-          <div class="text-center">
+            <div class="text-center">
             <button class="custom-flat-button" data-action="click->toggle#toggle">
               + Add a new flat
             </button>
-          </div>
+            </div>
 
           <div data-toggle-target="form" class="d-none mt-3" id="flat-form">
-            <%= simple_form_for Flat.new, url: flats_path, data: { turbo_frame: "new_flat" } do |f| %>
-
-              <div class="row">
-                <!-- Ligne 1 -->
-                <div class="col-md-6">
-                  <%= f.input :name %>
-                </div>
-                <div class="col-md-6">
-                  <%= f.input :description %>
-                </div>
-              </div>
-
-              <div class="row">
-                <!-- Ligne 2 -->
-                <div class="col-md-6">
-                  <%= f.input :address %>
-                </div>
-                <div class="col-md-6">
-                  <%= f.input :price %>
-                </div>
-              </div>
-
-              <div class="mb-3">
-                <%= f.input :photos, as: :file, input_html: { multiple: true } %>
-              </div>
-
-              <%= f.button :submit, "Créer le logement", class: "btn btn-primary" %>
-
-            <% end %>
+            <%= render partial: "flats/form", locals: {flat: Flat.new} %>
           </div>
 
         </div>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -83,20 +83,18 @@
 
     <!-- ➕ Ajouter un logement : bouton et formulaire centrés -->
     <div class="col-lg-12 d-flex flex-column align-items-center">
-      <turbo-frame id="new_flat" class="form-wrapper">
-        <div data-controller="toggle">
-            <div class="text-center">
-            <button class="custom-flat-button" data-action="click->toggle#toggle">
-              + Add a new flat
-            </button>
-            </div>
-
-          <div data-toggle-target="form" class="d-none mt-3" id="flat-form">
-            <%= render partial: "flats/form", locals: {flat: Flat.new} %>
-          </div>
-
+      <div data-controller="toggle">
+        <div class="text-center">
+          <button class="custom-flat-button" data-action="click->toggle#toggle">
+            + Add a new flat
+          </button>
         </div>
-      </turbo-frame>
+
+        <div data-toggle-target="form" class="d-none mt-3" id="flat-form">
+          <%= render partial: "flats/form", locals: {flat: Flat.new} %>
+        </div>
+
+      </div>
     </div>
 
   </div>

--- a/app/views/flats/_card.html.erb
+++ b/app/views/flats/_card.html.erb
@@ -1,0 +1,15 @@
+
+<%= turbo_frame_tag "flat_#{flat.id}" do %>
+  <li class="mb-3">
+    <div class="flat-item d-flex justify-content-between align-items-start">
+      <div>
+        <h5 class="mb-1"><%= flat.name %></h5>
+        <p class="mb-0 text-muted"><%= flat.address %></p>
+      </div>
+      <div class="btn-group">
+        <%= link_to 'Modifier', edit_flat_path(flat), class: 'btn btn-sm btn-outline-primary', data: { turbo_frame: "flat_#{flat.id}" } %>
+        <%= link_to 'Supprimer', flat, data: { turbo_method: :delete, turbo_confirm: "Es-tu sûr ?" }, class: 'btn btn-sm btn-outline-danger' %>
+      </div>
+    </div>
+  </li>
+<% end %>

--- a/app/views/flats/_card.html.erb
+++ b/app/views/flats/_card.html.erb
@@ -8,7 +8,7 @@
       </div>
       <div class="btn-group">
         <%= link_to 'Modifier', edit_flat_path(flat), class: 'btn btn-sm btn-outline-primary', data: { turbo_frame: "flat_#{flat.id}" } %>
-        <%= link_to 'Supprimer', flat, data: { turbo_method: :delete, turbo_confirm: "Es-tu sûr ?" }, class: 'btn btn-sm btn-outline-danger' %>
+        <%= link_to "Supprimer", flat, data: { turbo_method: :delete, turbo_confirm: "Supprimer ?" }, class: "btn btn-outline-danger" %>
       </div>
     </div>
   </li>

--- a/app/views/flats/_form.html.erb
+++ b/app/views/flats/_form.html.erb
@@ -1,0 +1,27 @@
+<%= turbo_frame_tag "new_flat" do %>
+  <%= simple_form_for flat, html: { multipart: true }, data: { turbo_frame: "new_flat" } do |f| %>
+    <div class="row">
+      <div class="col-md-6">
+        <%= f.input :name %>
+      </div>
+      <div class="col-md-6">
+        <%= f.input :description %>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-md-6">
+        <%= f.input :address %>
+      </div>
+      <div class="col-md-6">
+        <%= f.input :price %>
+      </div>
+    </div>
+
+    <div class="mb-3">
+      <%= f.input :photos, as: :file, input_html: { multiple: true } %>
+    </div>
+
+    <%= f.button :submit, "Créer le logement", class: "btn btn-primary" %>
+  <% end %>
+<% end %>

--- a/app/views/flats/create.turbo_stream.erb
+++ b/app/views/flats/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.append "flats-list" do %>
+  <%= render partial: "flats/card", locals: { flat: @flat } %>
+<% end %>
+
+<%= turbo_stream.replace "new_flat" do %>
+  <%= render partial: "flats/form", locals: { flat: Flat.new } %>
+<% end %>

--- a/app/views/flats/destroy.turbo_stream.erb
+++ b/app/views/flats/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "flat_#{@flat.id}" %>


### PR DESCRIPTION
✅ Modifications principales
	•	Intégration du formulaire de création d’un flat directement dans le dashboard, encapsulé dans un turbo-frame pour un rendu dynamique.
	•	Mise en place de la logique de création via Turbo Stream : une fois un flat créé, il est automatiquement ajouté à la liste sans rechargement de la page.
	•	Remplacement du formulaire par un nouveau vide après envoi (reset automatique).
	•	Ajout de la suppression via Turbo Stream : lorsqu’un flat est supprimé, son élément HTML est retiré instantanément de la page.
	•	Utilisation de turbo_stream_from pour maintenir à jour la liste en temps réel si d’autres utilisateurs y interagissent (si nécessaire dans le futur).

⸻

🧪 Comportement attendu
	•	Le bouton “Créer le logement” ajoute un flat et actualise dynamiquement la liste.
	•	Un message de confirmation peut être affiché via Turbo ou fallback HTML.
	•	Le bouton “Supprimer” retire le flat de l’interface sans rafraîchissement.
	•	Si le formulaire est invalide, les erreurs s’affichent dans le même cadre.